### PR TITLE
Various changes:

### DIFF
--- a/fdc1772.v
+++ b/fdc1772.v
@@ -169,8 +169,8 @@ always @(*) begin
 end
 
 always @(posedge clkcpu) begin
-	reg [3:0] img_mountedD;
-	reg [2:0] i;
+	reg [W:0] img_mountedD;
+	integer i;
 	img_mountedD <= img_mounted;
 	
 	for(i = 0; i < FD_NUM; i = i+1'd1) begin
@@ -891,7 +891,7 @@ end
 
 // the status byte
 wire [7:0] status = { (MODEL == 1 || MODEL == 3) ? !floppy_ready : motor_on,
-		      fd_writeprot,                        // wrprot
+		      (cmd[7:5] == 3'b101 || cmd[7:4] == 4'b1111 || cmd_type_1) && fd_writeprot, // wrprot (only for write!)
 		      cmd_type_1?motor_spin_up_done:1'b0,  // data mark
 		      RNF,                                 // seek error/record not found
 		      1'b0,                                // crc error

--- a/fdc1772.v
+++ b/fdc1772.v
@@ -300,6 +300,8 @@ wire       fd_writeprot   = fd_any ? img_wp[fdn]          : 1'b1;
 wire       fd_doubleside  = fdn_doubleside[fdn];
 wire [4:0] fd_spt         = fdn_spt[fdn];
 
+assign floppy_ready = fd_ready && fd_present;
+
 // -------------------------------------------------------------------------
 // ----------------------- internal state machines -------------------------
 // -------------------------------------------------------------------------
@@ -322,9 +324,7 @@ wire fd_motor = EXT_MOTOR ? floppy_motor : motor_on;
 
 // consider spin up done either if the motor is not supposed to spin at all or
 // if it's supposed to run and has left the spin up sequence
-wire motor_spin_up_done = (motor_spin_up_sequence == 0);
-assign floppy_ready = fd_ready && fd_present;
-
+wire motor_spin_up_done = (!motor_on) || (motor_on && (motor_spin_up_sequence == 0));
 
 // ---------------------------- step handling ------------------------------
 
@@ -365,7 +365,6 @@ always @(posedge clkcpu) begin
 	reg sector_not_found;
 	reg irq_at_index;
 	reg [1:0] data_transfer_state;
-	reg wait_for_motor;
 
 	sector_inc_strobe <= 1'b0;
 	track_inc_strobe <= 1'b0;
@@ -414,15 +413,12 @@ always @(posedge clkcpu) begin
 			notready_wait <= 1'b0;
 			sector_not_found <= 1'b0;
 			data_transfer_state <= 2'b00;
-			wait_for_motor <= 1'b0;
 
 			if(cmd_type_1 || cmd_type_2 || cmd_type_3) begin
 				RNF <= 1'b0;
+				motor_on <= 1'b1;
 				// 'h' flag '0' -> wait for spin up
-				if (!cmd[3]) begin
-					motor_on <= 1'b1;       // start the motor and
-					wait_for_motor <= 1'b1; // wait for 6 full rotations
-				end
+				if (!motor_on && !cmd[3]) motor_spin_up_sequence <= 6;   // wait for 6 full rotations
 			end
 
 			// handle "forced interrupt"
@@ -437,7 +433,7 @@ always @(posedge clkcpu) begin
 
 		// execute command if motor is not supposed to be running or
 		// wait for motor spinup to finish
-		if(busy && (motor_spin_up_done || !wait_for_motor) && !step_busy && !delaying) begin
+		if(busy && motor_spin_up_done && !step_busy && !delaying) begin
 
 			// ------------------------ TYPE I -------------------------
 			if(cmd_type_1) begin
@@ -669,7 +665,7 @@ always @(posedge clkcpu) begin
 			if (irq_at_index) irq_set <= 1'b1;
 
 			// let motor timeout run once fdc is not busy anymore
-			if(!busy && motor_on && motor_spin_up_done) begin
+			if(!busy && motor_spin_up_done) begin
 				if(motor_timeout_index != 0)
 					motor_timeout_index <= motor_timeout_index - 4'd1;
 				else if(motor_on)
@@ -683,7 +679,6 @@ always @(posedge clkcpu) begin
 				motor_spin_up_sequence <= motor_spin_up_sequence - 4'd1;
 		end
 		if(busy) motor_timeout_index <= 0;
-		if(!fd_motor) motor_spin_up_sequence <= 6;
 	end
 end
 

--- a/floppy.v
+++ b/floppy.v
@@ -19,11 +19,13 @@
 
 module floppy (
 	// main clock
-	input 	     clk,
-	input 	     select,
-	input 	     motor_on,
-	input 	     step_in,
-	input 	     step_out,
+	input        clk,
+	input        clk8m_en,
+
+	input        select,
+	input        motor_on,
+	input        step_in,
+	input        step_out,
 
 	input [10:0] sector_len,
 	input        sector_base,    // number of first sector on track (archie 0, dos 1)
@@ -32,38 +34,38 @@ module floppy (
 	input        hd,
 	input        fm,
 
-	output 	     dclk_en,      // data clock enable
+	output 	    dclk_en,      // data clock enable
 	output [6:0] track,        // number of track under head
 	output [4:0] sector,       // number of sector under head, 0 = no sector
-	output 	     sector_hdr,   // valid sector header under head
-	output 	     sector_data,  // valid sector data under head
+	output       sector_hdr,   // valid sector header under head
+	output       sector_data,  // valid sector data under head
 	       
-	output 	     ready,        // drive is ready, data can be read
+	output       ready,        // drive is ready, data can be read
 	output reg   index
 );
 
 // The sysclock is the value all floppy timings are derived from. 
 // Default: 8 MHz
-parameter SYS_CLK = 8000000;
+parameter CLK_EN = 8000;
 
 assign sector_hdr = (sec_state == SECTOR_STATE_HDR);
 assign sector_data = (sec_state == SECTOR_STATE_DATA);
 
 // a standard DD floppy has a data rate of 250kBit/s and rotates at 300RPM
-localparam RATESD = 20'd125000;
-localparam RATEDD = 20'd250000;
-localparam RATEHD = 20'd500000;
-localparam RPM = 10'd300;
-localparam STEPBUSY = 8'd18;       // 18ms after step data can be read
-localparam SPINUP = 10'd500;       // drive spins up in up to 800ms
-localparam SPINDOWN = 10'd300;     // GUESSED: drive spins down in 300ms
-localparam INDEX_PULSE_LEN = 4'd5; // fd1036 data sheet says 1~8ms
-localparam SECTOR_HDR_LEN = 4'd6;  // GUESSED: Sector header is 6 bytes
-localparam TRACKS = 8'd85;         // max allowed track
+localparam RATESD          = 125000;
+localparam RATEDD          = 250000;
+localparam RATEHD          = 500000;
+localparam RPM             = 300;
+localparam STEPBUSY        = 18;    // 18ms after step data can be read
+localparam SPINUP          = 500;   // drive spins up in up to 800ms
+localparam SPINDOWN        = 300;   // GUESSED: drive spins down in 300ms
+localparam INDEX_PULSE_LEN = 5;     // fd1036 data sheet says 1~8ms
+localparam SECTOR_HDR_LEN  = 6;     // GUESSED: Sector header is 6 bytes
+localparam TRACKS          = 85;    // max allowed track
 
 // Archimedes specific values
-//localparam SECTOR_LEN = 11'd1024 // Default sector size is 1024 on Archie
-//localparam SECTOR_LEN = 11'd512; // Default sector size is 512 on ST ...
+//localparam SECTOR_LEN = 11'd1024  // Default sector size is 1024 on Archie
+//localparam SECTOR_LEN = 11'd512;  // Default sector size is 512 on ST ...
 //localparam SPT = 4'd10;           // ... with 5 sectors per track
 //localparam SECTOR_BASE = 4'd1;    // number of first sector on track (archie 0, dos 1)
 
@@ -81,9 +83,9 @@ assign ready = select && (rate == (fm ? RATESD : hd ? RATEHD : RATEDD)) && (step
 
 // Index pulse generation. Pulse starts with the begin of index_pulse_start
 // and lasts INDEX_PULSE_CYCLES system clock cycles
-localparam INDEX_PULSE_CYCLES = INDEX_PULSE_LEN * SYS_CLK / 1000;
+localparam INDEX_PULSE_CYCLES = INDEX_PULSE_LEN * CLK_EN;
 reg [18:0] index_pulse_cnt;
-always @(posedge clk) begin
+always @(posedge clk) if(clk8m_en) begin
 	if(index_pulse_start && (index_pulse_cnt == INDEX_PULSE_CYCLES-1)) begin
 		index <= 1'b0;
 		index_pulse_cnt <= 19'd0;
@@ -97,7 +99,7 @@ end
 // ======================= track handling =========================
 // ================================================================
 
-localparam[19:0] STEP_BUSY_CLKS = (SYS_CLK/1000)*STEPBUSY;  // steprate is in ms
+localparam STEP_BUSY_CLKS = CLK_EN*STEPBUSY;  // steprate is in ms
 
 assign track = current_track;
 reg [6:0] current_track /* verilator public */ = 7'd0;
@@ -110,19 +112,19 @@ always @(posedge clk) begin
 	step_inD <= step_in;
 	step_outD <= step_out;
 
-	if(step_busy != 0)
+	if(clk8m_en && step_busy != 0)
 		step_busy <= step_busy - 18'd1;
 
 	if(select) begin
 		// rising edge of step signal starts step
 		if(step_in && !step_inD) begin
 			if(current_track != 0) current_track <= current_track - 7'd1;
-				step_busy <= STEP_BUSY_CLKS;
+				step_busy <= STEP_BUSY_CLKS[19:0];
 		end
 
 		if(step_out && !step_outD) begin
 			if(current_track != TRACKS-1) current_track <= current_track + 7'd1;
-				step_busy <= STEP_BUSY_CLKS;
+				step_busy <= STEP_BUSY_CLKS[19:0];
 		end
 	end
 end
@@ -159,12 +161,12 @@ always @(posedge clk) begin
 				case(sec_state)
 				SECTOR_STATE_GAP: begin
 					sec_state <= SECTOR_STATE_HDR;
-					sec_byte_cnt <= SECTOR_HDR_LEN-1'd1;
+					sec_byte_cnt <= SECTOR_HDR_LEN[9:0]-1'd1;
 				end
 	   
 				SECTOR_STATE_HDR: begin
 					sec_state <= SECTOR_STATE_DATA;
-					sec_byte_cnt <= sector_len-1'd1;
+					sec_byte_cnt <= sector_len[9:0]-1'd1;
 				end
 	   
 				SECTOR_STATE_DATA: begin
@@ -225,8 +227,8 @@ end
 
 // number of system clock cycles after which disk has reached
 // full speed
-localparam SPIN_UP_CLKS = SYS_CLK/1000*SPINUP;
-localparam SPIN_DOWN_CLKS = SYS_CLK/1000*SPINDOWN;
+localparam SPIN_UP_CLKS = CLK_EN*SPINUP;
+localparam SPIN_DOWN_CLKS = CLK_EN*SPINDOWN;
 reg [31:0] spin_up_counter;
 
 // internal motor on signal that is only true if the drive is selected
@@ -242,7 +244,7 @@ always @(posedge clk) begin
 	// reset spin_up counter whenever motor state changes
 	if(motor_onD != motor_on_sel)
 		spin_up_counter <= 32'd0;
-	else begin
+	else if(clk8m_en) begin
 		spin_up_counter <= spin_up_counter + (fm ? RATESD : hd ? RATEHD : RATEDD);
       
 		if(motor_on_sel) begin
@@ -271,12 +273,14 @@ reg data_clk_en;
 reg [31:0] clk_cnt;
 always @(posedge clk) begin
 	data_clk_en <= 0;
-	if(clk_cnt + rate > SYS_CLK/2) begin
-		clk_cnt <= clk_cnt - (SYS_CLK/2 - rate);
-		data_clk <= !data_clk;
-		if (~data_clk) data_clk_en <= 1;
-	end else
-		clk_cnt <= clk_cnt + rate;
+	if(clk8m_en) begin
+		if(clk_cnt + rate > CLK_EN*1000/2) begin
+			clk_cnt <= clk_cnt - (CLK_EN*1000/2 - rate);
+			data_clk <= !data_clk;
+			if (~data_clk) data_clk_en <= 1;
+		end else
+			clk_cnt <= clk_cnt + rate;
+	end
 end
 
 endmodule


### PR DESCRIPTION
While working on C1581 implementation for C64 core i've used your updated 1772 but it requires several changes:
- Define amount of supported floppies.
- External motor control (C1581 doesn't use MO signal from 1772)
- Export additional floppy signals (C1581 fdd mechanics has disk_change latch so additional signals from virtual floppy are required)
- Common CLK_EN parameter for all timings.
- Model definition for specific tweaks (1770 has other stepping rates than 1772).
- Inverted head number as a separate option (not a 1771 feature. As SIDE is controlled outside of 177x, it's up to specific implementation, it can be inverted in some schematics).
- CRC calculation for READ_ADDRESS reply (C1581 has sanity check against real CRC).
- 1771/1773 must provide floppy READY, not dummy image presence.